### PR TITLE
feat(api): make sign line length limit configurable

### DIFF
--- a/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/settings/PacketEventsSettings.java
@@ -40,6 +40,7 @@ public class PacketEventsSettings {
     private boolean fullStackTraceEnabled = false;
     private boolean kickOnPacketExceptionEnabled = true;
     private boolean kickIfTerminated = true;
+    private int signLineLengthLimit = 384;
     private Function<String, InputStream> resourceProvider = path -> PacketEventsSettings.class
             .getClassLoader()
             .getResourceAsStream(path);
@@ -153,6 +154,18 @@ public class PacketEventsSettings {
     }
 
     /**
+     * This decides the maximum amount of characters a single sign line may contain.
+     *
+     * @param signLineLengthLimit Value
+     * @return Settings instance.
+     */
+    @ApiStatus.Internal
+    public PacketEventsSettings signLineLengthLimit(int signLineLengthLimit) {
+        this.signLineLengthLimit = signLineLengthLimit;
+        return this;
+    }
+
+    /**
      * Some projects may want to implement a CDN with resources like asset mappings
      * By default, all resources are retrieved from the ClassLoader
      *
@@ -239,6 +252,15 @@ public class PacketEventsSettings {
      */
     public boolean isKickIfTerminated() {
         return kickIfTerminated;
+    }
+
+    /**
+     * Retrieve the maximum allowed characters per sign line.
+     *
+     * @return Getter for {@link #signLineLengthLimit}
+     */
+    public int getSignLineLengthLimit() {
+        return signLineLengthLimit;
     }
 
     /**

--- a/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
+++ b/api/src/main/java/com/github/retrooper/packetevents/wrapper/play/client/WrapperPlayClientUpdateSign.java
@@ -18,6 +18,7 @@
 
 package com.github.retrooper.packetevents.wrapper.play.client;
 
+import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketReceiveEvent;
 import com.github.retrooper.packetevents.manager.server.ServerVersion;
 import com.github.retrooper.packetevents.protocol.packettype.PacketType;
@@ -59,8 +60,9 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
             isFrontText = true;
         }
         textLines = new String[4];
+        int limit = PacketEvents.getAPI().getSettings().getSignLineLengthLimit();
         for (int i = 0; i < 4; i++) {
-            this.textLines[i] = readString(5000);
+            this.textLines[i] = readString(limit);
         }
     }
 
@@ -77,8 +79,9 @@ public class WrapperPlayClientUpdateSign extends PacketWrapper<WrapperPlayClient
         if (serverVersion.isNewerThanOrEquals(ServerVersion.V_1_20)) {
             writeBoolean(isFrontText);
         }
+        int limit = PacketEvents.getAPI().getSettings().getSignLineLengthLimit();
         for (int i = 0; i < 4; i++) {
-            writeString(textLines[i]);
+            writeString(textLines[i], limit);
         }
     }
 


### PR DESCRIPTION
## Summary
- allow configuring maximum sign line length through `PacketEventsSettings`
- respect configured sign line limit when reading/writing sign update packets

## Testing
- `./gradlew build` *(fails: Trust store file /usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/cacerts does not exist or is not readable. This may lead to SSL connection failures.)*

------
https://chatgpt.com/codex/tasks/task_e_689245bf39ec833399d9380b4b2de26b